### PR TITLE
ENH: add fetch-massbank action

### DIFF
--- a/q2_ms/__init__.py
+++ b/q2_ms/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2024, QIIME 2 development team.
+# Copyright (c) 2025, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_ms/plugin_setup.py
+++ b/q2_ms/plugin_setup.py
@@ -6,6 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 from q2_types.sample_data import SampleData
+from qiime2.core.type import Choices, Str
 from qiime2.plugin import Citations, Plugin
 
 from q2_ms import __version__
@@ -26,6 +27,7 @@ from q2_ms.types._format import (
     XCMSExperimentJSONFormat,
 )
 from q2_ms.types._type import MSP, XCMSExperiment
+from q2_ms.xcms.database import fetch_massbank
 
 citations = Citations.load("citations.bib", package="q2_ms")
 
@@ -36,6 +38,43 @@ plugin = Plugin(
     package="q2_ms",
     description="A QIIME 2 plugin for MS data processing.",
     short_description="A QIIME 2 plugin for MS data processing.",
+)
+
+plugin.methods.register_function(
+    function=fetch_massbank,
+    inputs={},
+    outputs=[("massbank", MSP)],
+    parameters={
+        "release": Str
+        % Choices(
+            "2024.11",
+            "2024.06",
+            "2023.11",
+            "2023.09",
+            "2023.06",
+            "2022.12.1",
+            "2022.12",
+            "2022.06",
+            "2021.12",
+            "2021.03",
+            "2021.02",
+            "2020.11",
+        ),
+    },
+    input_descriptions={},
+    output_descriptions={"massbank": "MassBank spectral library in NIST MSP format."},
+    parameter_descriptions={
+        "release": (
+            "Specify the release that you want to download. Per default the latest "
+            "release is downloaded."
+        ),
+    },
+    name="Fetch MassBank spectral library",
+    description=(
+        "Fetch the MassBank spectral library in NIST MSP format. It is downloaded from "
+        "github.com/MassBank/MassBank-data."
+    ),
+    citations=[],
 )
 
 # Registrations

--- a/q2_ms/plugin_setup.py
+++ b/q2_ms/plugin_setup.py
@@ -6,12 +6,11 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 from q2_types.sample_data import SampleData
-from qiime2.core.type import Choices, Str
 from qiime2.plugin import Citations, Plugin
 
 from q2_ms import __version__
-from q2_ms.types import mzML, mzMLDirFmt, mzMLFormat
-from q2_ms.types._format import (
+from q2_ms.types import (
+    MSP,
     MSBackendDataFormat,
     MSExperimentLinkMColsFormat,
     MSExperimentSampleDataFormat,
@@ -19,14 +18,17 @@ from q2_ms.types._format import (
     MSPDirFmt,
     MSPFormat,
     SpectraSlotsFormat,
+    XCMSExperiment,
     XCMSExperimentChromPeakDataFormat,
     XCMSExperimentChromPeaksFormat,
     XCMSExperimentDirFmt,
     XCMSExperimentFeatureDefinitionsFormat,
     XCMSExperimentFeaturePeakIndexFormat,
     XCMSExperimentJSONFormat,
+    mzML,
+    mzMLDirFmt,
+    mzMLFormat,
 )
-from q2_ms.types._type import MSP, XCMSExperiment
 from q2_ms.xcms.database import fetch_massbank
 
 citations = Citations.load("citations.bib", package="q2_ms")
@@ -44,35 +46,14 @@ plugin.methods.register_function(
     function=fetch_massbank,
     inputs={},
     outputs=[("massbank", MSP)],
-    parameters={
-        "release": Str
-        % Choices(
-            "2024.11",
-            "2024.06",
-            "2023.11",
-            "2023.09",
-            "2023.06",
-            "2022.12.1",
-            "2022.12",
-            "2022.06",
-            "2021.12",
-            "2021.03",
-            "2021.02",
-            "2020.11",
-        ),
-    },
+    parameters={},
     input_descriptions={},
     output_descriptions={"massbank": "MassBank spectral library in NIST MSP format."},
-    parameter_descriptions={
-        "release": (
-            "Specify the release that you want to download. Per default the latest "
-            "release is downloaded."
-        ),
-    },
+    parameter_descriptions={},
     name="Fetch MassBank spectral library",
     description=(
-        "Fetch the MassBank spectral library in NIST MSP format. It is downloaded from "
-        "github.com/MassBank/MassBank-data."
+        "Fetch the latest MassBank spectral library in NIST MSP format. It is "
+        "downloaded from github.com/MassBank/MassBank-data."
     ),
     citations=[],
 )

--- a/q2_ms/plugin_setup.py
+++ b/q2_ms/plugin_setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2024, QIIME 2 development team.
+# Copyright (c) 2025, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_ms/types/__init__.py
+++ b/q2_ms/types/__init__.py
@@ -22,7 +22,7 @@ from q2_ms.types._format import (
     mzMLDirFmt,
     mzMLFormat,
 )
-from q2_ms.types._type import XCMSExperiment, mzML
+from q2_ms.types._type import MSP, XCMSExperiment, mzML
 
 __all__ = [
     "mzMLFormat",
@@ -42,4 +42,5 @@ __all__ = [
     "XCMSExperiment",
     "MSPFormat",
     "MSPDirFmt",
+    "MSP",
 ]

--- a/q2_ms/types/__init__.py
+++ b/q2_ms/types/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2024, QIIME 2 development team.
+# Copyright (c) 2025, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_ms/types/_format.py
+++ b/q2_ms/types/_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2024, QIIME 2 development team.
+# Copyright (c) 2025, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_ms/types/_type.py
+++ b/q2_ms/types/_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2024, QIIME 2 development team.
+# Copyright (c) 2025, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_ms/types/tests/__init__.py
+++ b/q2_ms/types/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2024, QIIME 2 development team.
+# Copyright (c) 2025, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_ms/types/tests/test_formats.py
+++ b/q2_ms/types/tests/test_formats.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2024, QIIME 2 development team.
+# Copyright (c) 2025, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_ms/xcms/__init__.py
+++ b/q2_ms/xcms/__init__.py
@@ -1,0 +1,7 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2024, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------

--- a/q2_ms/xcms/__init__.py
+++ b/q2_ms/xcms/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2024, QIIME 2 development team.
+# Copyright (c) 2025, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_ms/xcms/database.py
+++ b/q2_ms/xcms/database.py
@@ -1,0 +1,35 @@
+import os
+
+import requests
+
+from q2_ms.types import MSPDirFmt
+
+
+def fetch_massbank(release: str = None) -> MSPDirFmt:
+    """
+    Downloads the MassBank_NIST.msp file from the specified release of the
+    MassBank-data repository.
+
+    Parameters:
+        release (str): The release version to download (e.g., '2024.11'). If None,
+        downloads the latest release.
+    """
+    massbank = MSPDirFmt()
+    base_url = "https://github.com/MassBank/MassBank-data/releases"
+
+    if release:
+        # Download from the specified release
+        download_url = f"{base_url}/download/{release}/MassBank_NIST.msp"
+    else:
+        # Download from the latest release
+        download_url = f"{base_url}/latest/download/MassBank_NIST.msp"
+
+    response = requests.get(download_url)
+
+    if response.status_code == 200:
+        with open(os.path.join(str(massbank), "MassBank_NIST.msp"), "wb") as file:
+            file.write(response.content)
+    else:
+        raise ValueError(f"Failed to download file. Code: {response.status_code}")
+
+    return massbank

--- a/q2_ms/xcms/database.py
+++ b/q2_ms/xcms/database.py
@@ -12,26 +12,17 @@ import requests
 from q2_ms.types import MSPDirFmt
 
 
-def fetch_massbank(release: str = None) -> MSPDirFmt:
+def fetch_massbank() -> MSPDirFmt:
     """
-    Downloads the MassBank_NIST.msp file from the specified release of the
-    MassBank-data repository.
-
-    Parameters:
-        release (str): The release version to download (e.g., '2024.11'). If None,
-        downloads the latest release.
+    Downloads the MassBank_NIST.msp file from the latest release of the MassBank-data
+    GitHub repository.
     """
     massbank = MSPDirFmt()
-    base_url = "https://github.com/MassBank/MassBank-data/releases"
 
-    if release:
-        # Download from the specified release
-        download_url = f"{base_url}/download/{release}/MassBank_NIST.msp"
-    else:
-        # Download from the latest release
-        download_url = f"{base_url}/latest/download/MassBank_NIST.msp"
-
-    response = requests.get(download_url)
+    response = requests.get(
+        "https://github.com/MassBank/MassBank-data/releases/latest/download"
+        "/MassBank_NIST.msp"
+    )
 
     if response.status_code == 200:
         with open(os.path.join(str(massbank), "MassBank_NIST.msp"), "wb") as file:

--- a/q2_ms/xcms/database.py
+++ b/q2_ms/xcms/database.py
@@ -1,3 +1,10 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2025, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
 import os
 
 import requests

--- a/q2_ms/xcms/tests/__init__.py
+++ b/q2_ms/xcms/tests/__init__.py
@@ -1,0 +1,7 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2024, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------

--- a/q2_ms/xcms/tests/__init__.py
+++ b/q2_ms/xcms/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2024, QIIME 2 development team.
+# Copyright (c) 2025, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_ms/xcms/tests/tests_database.py
+++ b/q2_ms/xcms/tests/tests_database.py
@@ -11,6 +11,7 @@ from unittest.mock import Mock, patch
 
 from qiime2.plugin.testing import TestPluginBase
 
+from q2_ms.types import MSPDirFmt
 from q2_ms.xcms.database import fetch_massbank
 
 
@@ -31,6 +32,7 @@ class TestmzMLFormats(TestPluginBase):
         # Check if the file exists
         file_path = os.path.join(str(result), "MassBank_NIST.msp")
         self.assertTrue(os.path.exists(file_path))
+        self.assertIsInstance(result, MSPDirFmt)
 
     @patch("q2_ms.xcms.database.requests.get")
     def test_fetch_massbank_error(self, mock_get):

--- a/q2_ms/xcms/tests/tests_database.py
+++ b/q2_ms/xcms/tests/tests_database.py
@@ -1,0 +1,48 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2024, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+import os
+import unittest
+from unittest.mock import Mock, patch
+
+from qiime2.plugin.testing import TestPluginBase
+
+from q2_ms.xcms.database import fetch_massbank
+
+
+class TestmzMLFormats(TestPluginBase):
+    package = "q2_ms.types.tests"
+
+    @patch("q2_ms.xcms.database.requests.get")
+    def test_fetch_massbank(self, mock_get):
+        # Mock the response object
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.content = b""
+        mock_get.return_value = mock_response
+
+        # Call the function
+        result = fetch_massbank()
+
+        # Check if the file exists
+        file_path = os.path.join(str(result), "MassBank_NIST.msp")
+        self.assertTrue(os.path.exists(file_path))
+
+    @patch("q2_ms.xcms.database.requests.get")
+    def test_fetch_massbank_error(self, mock_get):
+        # Mock the response object
+        mock_response = Mock()
+        mock_response.status_code = 502
+        mock_response.content = b""
+        mock_get.return_value = mock_response
+
+        with self.assertRaisesRegex(ValueError, "502"):
+            fetch_massbank()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/q2_ms/xcms/tests/tests_database.py
+++ b/q2_ms/xcms/tests/tests_database.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2024, QIIME 2 development team.
+# Copyright (c) 2025, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #


### PR DESCRIPTION
closes #24 
depends on #26 
depends on #8 

Added action 'fetch-massbank' that downloads the MassBank_NIST.msp file from the specified release of the MassBank-data repository in MSP format.