### PR TITLE
MAINT: Change in precommit whitespace removal

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,9 @@ repos:
     rev: v2.3.0
     hooks:
       - id: end-of-file-fixer
+        exclude: ".*/data/.*"
       - id: trailing-whitespace
+        exclude: ".*/data/.*"
       - id: check-merge-conflict
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0


### PR DESCRIPTION
The precommit hooks were removing trailing white spaces in all package files. This lead to errors because also test data was altered. To remove this problem all directories called data have been excluded from the precommit hooks.