### PR TITLE
ENH: add semantic validators for the type XCMSExperiment with properties MS2, peaks and features

### DIFF
--- a/q2_ms/plugin_setup.py
+++ b/q2_ms/plugin_setup.py
@@ -5,6 +5,8 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
+import importlib
+
 from q2_types.sample_data import SampleData
 from qiime2.plugin import Citations, Metadata, Plugin
 
@@ -128,3 +130,5 @@ plugin.register_formats(
     MatchedSpectraFormat,
     MatchedSpectraDirFmt,
 )
+
+importlib.import_module("q2_ms.types._validators")

--- a/q2_ms/types/_validators.py
+++ b/q2_ms/types/_validators.py
@@ -26,6 +26,7 @@ def validate_xcms_experiment_ms2(data: XCMSExperimentDirFmt, level):
         sep="\t",
         usecols=["msLevel"],
         skiprows=1,
+        index_col=0,
     )
     if not (df["msLevel"] == 2).any():
         raise ValidationError(

--- a/q2_ms/types/_validators.py
+++ b/q2_ms/types/_validators.py
@@ -1,0 +1,69 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2025, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+import os
+
+import pandas as pd
+from qiime2.core.exceptions import ValidationError
+from qiime2.core.type import Properties
+
+from q2_ms.plugin_setup import plugin
+from q2_ms.types import XCMSExperiment, XCMSExperimentDirFmt
+
+
+@plugin.register_validator(XCMSExperiment % Properties("MS2"))
+def validate_xcms_experiment_ms2(data: XCMSExperimentDirFmt, level):
+    """
+    Validates that the XCMSExperiment contains MS2-level spectra. Checks for any "2"
+    values in the "msLevel" column in the file "ms_backend_data.txt".
+    """
+    df = pd.read_csv(
+        os.path.join(data.path, "ms_backend_data.txt"),
+        sep="\t",
+        usecols=["msLevel"],
+        skiprows=1,
+    )
+    if not (df["msLevel"] == 2).any():
+        raise ValidationError(
+            "The property 'MS2' requires MS2-level spectra to be present in the "
+            "XCMSExperiment."
+        )
+
+
+@plugin.register_validator(XCMSExperiment % Properties("peaks"))
+def validate_xcms_experiment_peaks(data: XCMSExperimentDirFmt, level):
+    """
+    Validates that required chromatographic peak files exist in the XCMSExperiment.
+    """
+    files = ["xcms_experiment_chrom_peaks.txt", "xcms_experiment_chrom_peak_data.txt"]
+    if not any(os.path.exists(os.path.join(data.path, f)) for f in files):
+        raise ValidationError(
+            "The property 'peaks' requires the two files "
+            "'xcms_experiment_chrom_peaks.txt' and "
+            "'xcms_experiment_chrom_peak_data.txt' to be present in the "
+            "XCMSExperiment. To identify chromatographic peaks use the action "
+            "'find-chrom-peaks-centwave'."
+        )
+
+
+@plugin.register_validator(XCMSExperiment % Properties("features"))
+def validate_xcms_experiment_features(data: XCMSExperimentDirFmt, level):
+    """
+    Validates that required feature grouping files exist in the XCMSExperiment.
+    """
+    files = [
+        "xcms_experiment_feature_definitions.txt",
+        "xcms_experiment_feature_peak_index.txt",
+    ]
+    if not any(os.path.exists(os.path.join(data.path, f)) for f in files):
+        raise ValidationError(
+            "The property 'features' requires the two files "
+            "'xcms_experiment_feature_definitions.txt' and "
+            "'xcms_experiment_feature_peak_index.txt' to be present in the "
+            "XCMSExperiment. To group peaks into features use the action "
+            "'group-chrom-peaks-density'."
+        )

--- a/q2_ms/types/tests/data/ms_backend_MS2/ms_backend_data.txt
+++ b/q2_ms/types/tests/data/ms_backend_MS2/ms_backend_data.txt
@@ -1,4 +1,4 @@
 # MsBackendMzR
-"msLevel"	"rtime"	"acquisitionNum"	"dataOrigin"	"polarity"	"precScanNum"	"precursorMz"	"precursorIntensity"	"precursorCharge"	"collisionEnergy"	"peaksCount"	"totIonCurrent"	"basePeakMZ"	"basePeakIntensity"	"ionisationEnergy"	"lowMZ"	"highMZ"	"mergedScan"	"mergedResultScanNum"	"mergedResultStartScanNum"	"mergedResultEndScanNum"	"injectionTime"	"spectrumId"	"ionMobilityDriftTime"	"dataStorage"	"scanIndex"
-"1"	1	2551.457	33	"/Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/library/faahKO/cdf/KO/ko15.CDF"	-1	-1	-1	-1	-1	-1	1	950104	-1	-1	-1	-1	-1	-1	-1	-1	-1	-1	"scan=33"	-1	"/Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/library/faahKO/cdf/KO/ko15.CDF"	33
-"2"	2	2553.022	34	"/Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/library/faahKO/cdf/KO/ko15.CDF"	-1	-1	-1	-1	-1	-1	1	950831	-1	-1	-1	-1	-1	-1	-1	-1	-1	-1	"scan=34"	-1	"/Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/library/faahKO/cdf/KO/ko15.CDF"	34
+"msLevel"	"rtime"	"acquisitionNum"
+"1"	1	2551.457	33
+"2"	2	2553.022	34

--- a/q2_ms/types/tests/data/ms_backend_MS2/ms_backend_data.txt
+++ b/q2_ms/types/tests/data/ms_backend_MS2/ms_backend_data.txt
@@ -1,0 +1,4 @@
+# MsBackendMzR
+"msLevel"	"rtime"	"acquisitionNum"	"dataOrigin"	"polarity"	"precScanNum"	"precursorMz"	"precursorIntensity"	"precursorCharge"	"collisionEnergy"	"peaksCount"	"totIonCurrent"	"basePeakMZ"	"basePeakIntensity"	"ionisationEnergy"	"lowMZ"	"highMZ"	"mergedScan"	"mergedResultScanNum"	"mergedResultStartScanNum"	"mergedResultEndScanNum"	"injectionTime"	"spectrumId"	"ionMobilityDriftTime"	"dataStorage"	"scanIndex"
+"1"	1	2551.457	33	"/Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/library/faahKO/cdf/KO/ko15.CDF"	-1	-1	-1	-1	-1	-1	1	950104	-1	-1	-1	-1	-1	-1	-1	-1	-1	-1	"scan=33"	-1	"/Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/library/faahKO/cdf/KO/ko15.CDF"	33
+"2"	2	2553.022	34	"/Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/library/faahKO/cdf/KO/ko15.CDF"	-1	-1	-1	-1	-1	-1	1	950831	-1	-1	-1	-1	-1	-1	-1	-1	-1	-1	"scan=34"	-1	"/Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/library/faahKO/cdf/KO/ko15.CDF"	34

--- a/q2_ms/types/tests/test_validators.py
+++ b/q2_ms/types/tests/test_validators.py
@@ -1,0 +1,47 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2025, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+from qiime2.core.exceptions import ValidationError
+from qiime2.plugin.testing import TestPluginBase
+
+from q2_ms.types import XCMSExperimentDirFmt
+from q2_ms.types._validators import (
+    validate_xcms_experiment_features,
+    validate_xcms_experiment_ms2,
+    validate_xcms_experiment_peaks,
+)
+
+
+class TestValidators(TestPluginBase):
+    package = "q2_ms.types.tests"
+
+    def test_validate_xcms_experiment_ms2_error(self):
+        data = XCMSExperimentDirFmt(self.get_data_path("XCMSExperiment"), mode="r")
+        with self.assertRaisesRegex(ValidationError, "The property 'MS2'"):
+            validate_xcms_experiment_ms2(data, None)
+
+    def test_validate_xcms_experiment_ms2(self):
+        data = XCMSExperimentDirFmt(self.get_data_path("ms_backend_MS2"), mode="r")
+        validate_xcms_experiment_ms2(data, None)
+
+    def test_validate_xcms_experiment_peaks_error(self):
+        data = XCMSExperimentDirFmt(self.temp_dir.name, mode="r")
+        with self.assertRaisesRegex(ValidationError, "The property 'peaks'"):
+            validate_xcms_experiment_peaks(data, None)
+
+    def test_validate_xcms_experiment_peaks(self):
+        data = XCMSExperimentDirFmt(self.get_data_path("XCMSExperiment"), mode="r")
+        validate_xcms_experiment_peaks(data, None)
+
+    def test_validate_xcms_experiment_features_error(self):
+        data = XCMSExperimentDirFmt(self.temp_dir.name, mode="r")
+        with self.assertRaisesRegex(ValidationError, "The property 'features'"):
+            validate_xcms_experiment_features(data, None)
+
+    def test_validate_xcms_experiment_features(self):
+        data = XCMSExperimentDirFmt(self.get_data_path("XCMSExperiment"), mode="r")
+        validate_xcms_experiment_features(data, None)


### PR DESCRIPTION
closes #46 

Adds semantic validators for the type XCMSExperiment with properties MS2, peaks and features.